### PR TITLE
Add another solution to "normalize"

### DIFF
--- a/chapter7.ml
+++ b/chapter7.ml
@@ -84,6 +84,11 @@
    let n = norm v in (* Must calculate norm before iteration *)
    Array.iteri (fun i x -> v.(i) <- x /. n) v
 
+ (* since OCaml 5.1 *)
+ let normalize' (v : vector) =
+   let n = norm v in
+   Array.map_inplace (fun x -> x /. n) v
+
 
  (********************************************************************
   * exercise: normalize loop


### PR DESCRIPTION
OCaml 5.1 introduced the function [`Array.map_inplace`][1]:

> ```ocaml
> val map_inplace : ('a -> 'a) -> 'a array -> unit
> ```
> 
> `map_inplace f a` applies function `f` to all elements of `a`, and updates their values in place.
>
> **Since** 5.1

This new function allows for another (more elegant) solution to the exercise “normalize”.

[1]: https://v2.ocaml.org/api/Array.html#1_Iterators