### PR TITLE
Chapter 6b solutions: change {evaluation} into {algebra} in a couple cases

### DIFF
--- a/chapter6b.txt
+++ b/chapter6b.txt
@@ -10,13 +10,13 @@ Base case: m = 0
 Show: exp x (0 + n) = exp x 0 * exp x n
 
   exp x (0 + n)
-=   { evaluation }
+=   { algebra }
   exp x n
 
   exp x 0 * exp x n
 =   { evaluation }
   1 * exp x n
-=   { evaluation }
+=   { algebra }
   exp x n
 
 Inductive case: m = k + 1


### PR DESCRIPTION
The proof of exercise `exp` incorrectly used the rule `{evaluation}` in a few cases when it was merely doing algebra. This PR fixes those cases.